### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   es:
-    image: elasticsearch
+    image: elasticsearch:2.3
   web:
     image: prakhar1989/foodtrucks-web
     command: python app.py


### PR DESCRIPTION
There is an error when trying to use latest elastic search. Falling back to 2.3 works. See https://github.com/docker-library/elasticsearch/issues/98#issuecomment-225195625