### PR TITLE
Replace deprecated MAINTAINER instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # start from base
 FROM ubuntu:latest
-MAINTAINER Prakhar Srivastav <prakhar@prakhar.me>
+
+LABEL maintainer="Prakhar Srivastav <prakhar@prakhar.me>"
 
 # install system-wide deps for python and node
 RUN apt-get -yqq update


### PR DESCRIPTION
The MAINTAINER instruction has been deprecated in favour of LABEL.
(See https://docs.docker.com/engine/reference/builder/#maintainer-deprecated).
Lets keep the tutorial up to date so newbies won't be encouraged to mimic
the old style.

_A corresponding PR to be made in `docker-curriculum`_
