### PR TITLE
fix ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # start from base
-FROM ubuntu:latest
+FROM ubuntu:18.04
 
 LABEL maintainer="Prakhar Srivastav <prakhar@prakhar.me>"
 


### PR DESCRIPTION
it seems the ubuntu version has rolled to a new version which doesnt have the universe repo in, so python-pip isn't available. suggesting pinning ubuntu version to one which includes it by default.